### PR TITLE
新增推送与合并请求时的自动检查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: 检查
+
+# 推送到 main 以及所有指向 main 的 PR 都会跑。
+# 发版用的 release.yml 只在推 tag 时触发，两者互不影响。
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# 同一分支上有新提交时，取消还在跑的旧任务，避免浪费额度
+concurrency:
+  group: 检查-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: 代码检查与构建
+    runs-on: ubuntu-latest
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v5
+
+      - name: 准备 Node 环境
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: 安装依赖
+        run: npm ci
+
+      # 这一步最关键：模块之间遗漏的引用只有它能查出来，构建阶段不会报错
+      - name: 代码检查
+        run: npm run lint
+
+      - name: 类型检查
+        run: npm run typecheck
+
+      # build 内部已包含版本号一致性校验（scripts/verify-version.mjs）
+      - name: 构建
+        run: npm run build
+
+      # 把构建好的脚本挂到本次运行上，PR 里可以直接下载安装试用，
+      # 不必在本地拉分支重新构建。保留两周。
+      - name: 上传构建产物
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdcasSK-user-script
+          path: dist/cdcasSK.user.js
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ scripts/
 └── release-notes.mjs      从 CHANGELOG.md 提取指定版本章节，供发布流程使用
 
 .github/workflows/
+├── ci.yml                 推送到 main 及 PR 时跑检查与构建
 └── release.yml            推送 v 开头的 tag 时自动构建并创建 Release
 ```
 
@@ -46,6 +47,9 @@ scripts/
 - `npm run dev` 开发（热更新，不用反复重装脚本）
 - `npm run build` 打包到 `dist/cdcasSK.user.js`
 - `npm run lint` 检查，**改完模块结构必跑** —— 漏掉的 import 只有它能查出来，构建不会报错
+- `npm run typecheck` 类型检查
+
+以上三项 CI 会在推送到 main 和提 PR 时自动跑一遍，但本地先跑能省一个来回。
 - `npm version patch|minor|major` 发版（自动跑检查、改版本、打 tag、重新构建）
 - `git push --follow-tags` 推送 tag，触发 GitHub Actions 自动建 Release
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ npm install
 | `npm run typecheck` | TypeScript 检查 `vite.config.ts` |
 | `npm version patch` | 发版：见下方「版本号与发版」 |
 
+推送到 `main` 和提 PR 时，[检查工作流](.github/workflows/ci.yml)会自动跑上面的 `lint`、`typecheck`、`build`，并把构建好的脚本挂在运行记录里，可以直接下载安装试用。
+
 目录结构：
 
 ```


### PR DESCRIPTION
补上推送与合并请求时的自动检查。

## 为什么

合并 #7 之后仓库只有 `release.yml`，它**只在推 tag 时触发**。也就是说 lint 不过、构建失败的提交可以直接进 main，要等到发版那一刻才暴露。这个缺口对本项目影响不小——模块拆分之后，遗漏的 `import` 只有 ESLint 查得出来，构建阶段不会报错（Rollup 会把未声明的标识符当全局留着，装到浏览器里才 ReferenceError）。

## 改了什么

新增 `.github/workflows/ci.yml`，在推送到 `main` 和所有指向 `main` 的 PR 上跑：

1. `npm ci`
2. `npm run lint`
3. `npm run typecheck`
4. `npm run build`（内含版本号一致性校验）

另外两点：

- **构建产物挂到运行记录上**，保留两周。审 PR 时可以直接下载那个 `.user.js` 装进油猴试用，不用在本地拉分支重新构建。对这种改动难以静态审阅的项目挺实用。
- **并发控制**，同一分支有新提交时取消还在跑的旧任务，省额度。

## 自我验证

这个 PR 本身就会被它新增的工作流检查——如果下面的检查跑起来并通过了，说明配置是对的。

## 合并后

可以开启分支保护了。建议的组合：

- 禁止强制推送、禁止删除分支（零摩擦的保险）
- 要求 `代码检查与构建` 这个检查通过后才能合并（现在才有东西可要求）
- 不建议要求「必须走 PR」——单人维护，改个错别字还要开 PR 太折腾
